### PR TITLE
Added react-tools and jsx requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Note that reporting user points will not work unless you have an annointed key.
 See here for information on how to apply for a Khan Academy API key:  
 https://github.com/Khan/khan-api/wiki/Khan-Academy-API-Authentication
 
+## Building the source
+
+You need [Nodejs](http://nodejs.org) installed to run the following commands (please run them in the order given).
+
+* Install react-tools by running `npm install -g react-tools`.
+
+* Install jsx by running `npm install -g jsx`
+
 The first time you get setup, run `./rebuild`.  Then run `./runserver`.  
 This will start a local python HTTP server on port 8092.  
 It will also start watching js and jsx changes and transpile everything in the `./js` directory to the `./build` directory.  In this way React and ES6 features can be used.


### PR DESCRIPTION
Adding the following comments in case someone already has `jsx` installed & faces the issue I did.

Got a `jsx: command not found` when I first ran `./rebuild`. So I installed `jsx` & got `unknown option: --harmony`. That's a `react-tools` flag, which I didn't have installed and trying to install it via npm gave me the following error.

```
npm ERR! Refusing to delete: /usr/local/bin/jsx not in /usr/local/lib/node_modules/react-tools
File exists: /usr/local/bin/jsx
Move it away, and try again.
```

So I deleted that jsx file and the react-tools installation went smoothly and I was able to `./rebuild`
