### PR TITLE
Remove npm install jsx from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ https://github.com/Khan/khan-api/wiki/Khan-Academy-API-Authentication
 
 You need [Nodejs](http://nodejs.org) installed to run the following commands (please run them in the order given).
 
-* Install react-tools by running `npm install -g react-tools`.
+* Install react-tools by running `npm install -g react-tools`. This includes `jsx`.
 
-* Install jsx by running `npm install -g jsx`.  Make sure you're using at least 0.12.0 by running `jsx --version`.
+* Make sure you're using at least 0.12.0 by running `jsx --version`.
 
 The first time you get setup, run `./tools/rebuild`.  Then run `./tools/runserver`.  
 This will start a local python HTTP server on port 8092.  


### PR DESCRIPTION
Latest `jsx` is included in `react-tools` and `npm install -g jsx` installs an older version, so I removed the latter.
