### PR TITLE
Allow cancellation of individual downloads

### DIFF
--- a/js/downloads.js
+++ b/js/downloads.js
@@ -155,6 +155,7 @@ define(["jquery", "underscore", "util", "storage", "models", "apiclient"],
                 req.open("GET", url, true);
                 req.responseType = "arraybuffer";
                 req.onload = () => {
+                    models.TempAppState.set("currentDownloadRequest", null);
                     handleContentLoaded(req.response);
                 };
                 req.onabort = (e) => {

--- a/js/views/chrome.js
+++ b/js/views/chrome.js
@@ -181,7 +181,7 @@ define(["jquery", "react", "util", "models", "apiclient", "cache", "storage",
             }
 
             if (Storage.isEnabled()) {
-                if (models.TempAppState.get("isDownloadingTopic")) {
+                if (models.TempAppState.get("isDownloadingTopic") || models.TempAppState.get("currentDownloadRequest")) {
                     items.push(<li key="cancel-downloading" className="hot-item">
                             <a href="#" data-l10n-id="cancel-downloading" onClick={Util.partial(this.props.onClickCancelDownloadContent, this.props.model)}>Cancel Downloading</a>
                         </li>);


### PR DESCRIPTION
Fixes #54, which basically already worked with PR 59, but this adds the ui element and and clears the download state on completion so we know when not to show it.
